### PR TITLE
Maximum likelihood learning definition

### DIFF
--- a/learning/directed/index.md
+++ b/learning/directed/index.md
@@ -50,7 +50,7 @@ where $$D$$ is a dataset drawn i.i.d. from $$p^*$$.
 
 Maximum likelihood learning is then defined as
 {% math %}
-\max_{p \in M} \frac{1}{|D|} \sum_{x \in D}  \log p(x), 
+\arg\max_{p \in M} \frac{1}{|D|} \sum_{x \in D}  \log p(x), 
 {% endmath %}
 
 ### An example


### PR DESCRIPTION
The purpose of MLL is to find the p that maximizes this expression, not to find the maximum value of the expression itself - so I believe it would be clearer to express this as an argmax instead of a max.